### PR TITLE
Add pythonanywhere 0.10.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+
+channels:
+  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,8 @@ package:
 
 build:
   number: 0
-  skip: True  # [py<36]
+  # docopt currently is not available on s390x
+  skip: True  # [py<36 or s390x]
   script: {{ PYTHON }} -m pip install . -vv
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
+  license_url: https://github.com/pythonanywhere/helper_scripts/blob/master/LICENSE
   dev_url: https://github.com/pythonanywhere/helper_scripts/
   doc_url: https://github.com/pythonanywhere/helper_scripts/blob/master/README.md
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   dev_url: https://github.com/pythonanywhere/helper_scripts/
-  doc_url: 
+  doc_url: https://github.com/pythonanywhere/helper_scripts/blob/master/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,7 @@ package:
 
 build:
   number: 0
-  # docopt currently is not available on s390x
-  skip: True  # [py<36 or s390x]
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . -vv
 
 source:
@@ -40,6 +39,7 @@ test:
     - pip
   commands:
     - pip check
+    - pa --help
 
 about:
   home: https://github.com/pythonanywhere/helper_scripts/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "pythonanywhere" %}
+{% set version = "0.10.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pythonanywhere-{{ version }}.tar.gz
+  sha256: a33664b51b37df00964cac4ac2481226adc595471a3855b6bbb27e33eee98574
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python
+    - docopt
+    - packaging
+    - python-dateutil
+    - requests
+    - schema
+    - tabulate
+    - typer
+
+test:
+  imports:
+    - cli
+    - pythonanywhere
+    - pythonanywhere.api
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/pythonanywhere/helper_scripts/
+  summary: PythonAnywhere helper tools for users
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/pythonanywhere/helper_scripts/
+  doc_url: 
+
+extra:
+  recipe-maintainers:
+    - bkreider
+    - skupr-anaconda


### PR DESCRIPTION
License: https://github.com/pythonanywhere/helper_scripts/blob/master/LICENSE
Changelog: https://github.com/pythonanywhere/helper_scripts/releases
Requirements: https://github.com/pythonanywhere/helper_scripts/blob/v0.10.2/setup.py

Actions:
1. Add a new recipe